### PR TITLE
Fix #6: Remove ColumbusPHP feed endpoint.

### DIFF
--- a/run.php
+++ b/run.php
@@ -9,14 +9,23 @@
 $loader = require 'vendor/autoload.php';
 $loader->register();
 
-use ColumbusPHP\PokerHand\Feed\PokerHandFeedColumbusPHP;
+use ColumbusPHP\PokerHand\Feed\PokerHandFeedDummy;
+use ColumbusPHP\PokerHand\Feed\PokerHandFeedRemote;
 use ColumbusPHP\PokerHand\Collection\PokerHandCollection;
 use GuzzleHttp\Client;
 
 try {
   // Get a poker hand collection and rank 'em.
   $client = new Client();
-  $hands = PokerHandCollection::createFromFeed(new PokerHandFeedColumbusPHP($client));
+
+  // Check if there is a URL parameter and use the appropriate feed.
+  if (!isset($argv[1]) || filter_var($argv[1], FILTER_VALIDATE_URL) === FALSE) {
+    print "\nUsing dummy feed:\n\n";
+    $hands = PokerHandCollection::createFromFeed(new PokerHandFeedDummy($client));
+  } else {
+    print "\nUsing remote feed:\n\n";
+    $hands = PokerHandCollection::createFromFeed(new PokerHandFeedRemote($client, $argv[1]));
+  }
 
   $hands->rankHands()->sortHands();
 

--- a/src/PokerHand/Collection/PokerHandCollection.php
+++ b/src/PokerHand/Collection/PokerHandCollection.php
@@ -43,7 +43,7 @@ class PokerHandCollection {
    *   PokerHandCollection object
    */
   static public function createFromFeed(PokerHandFeedInterface $feed) {
-    $raw = $feed->getData($feed::$url);
+    $raw = $feed->getData($feed -> getUrl());
 
     return new static($feed->parseData($raw));
   }

--- a/src/PokerHand/Feed/PokerHandFeedRemote.php
+++ b/src/PokerHand/Feed/PokerHandFeedRemote.php
@@ -10,14 +10,14 @@ use ColumbusPHP\PokerHand\Feed\PokerHandFeedInterface;
 use GuzzleHttp\Exception\RequestException;
 
 /**
- * Fetch the poker hands from Bill Condo's feed.
+ * Fetch the poker hands from a remote feed.
  */
-class PokerHandFeedColumbusPHP implements PokerHandFeedInterface {
+class PokerHandFeedRemote implements PokerHandFeedInterface {
 
   /**
-   * {@inheritdoc }
+   * @var string
    */
-  static public $url = 'http://poker.columbusphp.org/hand';
+  static public $url = '';
 
   /**
    * @var \GuzzleHttp\ClientInterface
@@ -30,7 +30,8 @@ class PokerHandFeedColumbusPHP implements PokerHandFeedInterface {
    * @param \GuzzleHttp\ClientInterface $client
    *   A guzzle client.
    */
-  public function __construct(\GuzzleHttp\ClientInterface $client) {
+  public function __construct(\GuzzleHttp\ClientInterface $client, $feed = 'http://poker.columbusphp.org/hand') {
+    $this -> url = $feed;
     $this->client = $client;
   }
 

--- a/src/PokerHand/Feed/PokerHandFeedRemote.php
+++ b/src/PokerHand/Feed/PokerHandFeedRemote.php
@@ -39,7 +39,7 @@ class PokerHandFeedRemote implements PokerHandFeedInterface {
    * {@inheritdoc }
    */
   public function getUrl() {
-    return $this -> $url;
+    return $this -> url;
   }
 
   /**

--- a/src/PokerHand/Feed/PokerHandFeedRemote.php
+++ b/src/PokerHand/Feed/PokerHandFeedRemote.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * PokerHandFeedColumbusPHP.php
+ * PokerHandFeedRemote.php
  */
 
 namespace ColumbusPHP\PokerHand\Feed;

--- a/src/PokerHand/Feed/PokerHandFeedRemote.php
+++ b/src/PokerHand/Feed/PokerHandFeedRemote.php
@@ -31,7 +31,7 @@ class PokerHandFeedRemote implements PokerHandFeedInterface {
    *   A guzzle client.
    */
   public function __construct(\GuzzleHttp\ClientInterface $client, $feed = 'http://poker.columbusphp.org/hand') {
-    $this -> url = $feed;
+    $this->url = $feed;
     $this->client = $client;
   }
 
@@ -39,7 +39,7 @@ class PokerHandFeedRemote implements PokerHandFeedInterface {
    * {@inheritdoc }
    */
   public function getUrl() {
-    return $this -> url;
+    return $this->url;
   }
 
   /**

--- a/src/PokerHand/Feed/PokerHandFeedRemote.php
+++ b/src/PokerHand/Feed/PokerHandFeedRemote.php
@@ -17,7 +17,7 @@ class PokerHandFeedRemote implements PokerHandFeedInterface {
   /**
    * @var string
    */
-  static public $url = '';
+  public $url = '';
 
   /**
    * @var \GuzzleHttp\ClientInterface
@@ -39,7 +39,7 @@ class PokerHandFeedRemote implements PokerHandFeedInterface {
    * {@inheritdoc }
    */
   public function getUrl() {
-    return self::$url;
+    return $this -> $url;
   }
 
   /**

--- a/tests/PokerHandFeedRemoteTest.php
+++ b/tests/PokerHandFeedRemoteTest.php
@@ -1,22 +1,22 @@
 <?php
 /**
  * @file
- * Stuff
+ * PokerHandFeedRemoteTest.php
  */
 
-use ColumbusPHP\PokerHand\Feed\PokerHandFeedColumbusPHP;
+use ColumbusPHP\PokerHand\Feed\PokerHandFeedRemote;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 
-class PokerHandFeedColumbusPHPTest extends PHPUnit_Framework_TestCase {
+class PokerHandFeedRemoteTest extends PHPUnit_Framework_TestCase {
 
   /**
    * Tests the get url method.
    */
   public function testGetUrl() {
-    $feed = new PokerHandFeedColumbusPHP(new Client());
+    $feed = new PokerHandFeedRemote(new Client(), 'http://poker.columbusphp.org/hand');
     $this->assertEquals('http://poker.columbusphp.org/hand', $feed->getUrl());
   }
 
@@ -47,7 +47,7 @@ class PokerHandFeedColumbusPHPTest extends PHPUnit_Framework_TestCase {
     ]);
     $handler = HandlerStack::create($mock);
     $client = new Client(['handler' => $handler]);
-    $feed = new PokerHandFeedColumbusPHP($client);
+    $feed = new PokerHandFeedRemote($client);
 
     // Get the raw data.
     $data = $feed->getData($feed->getUrl());
@@ -70,7 +70,7 @@ class PokerHandFeedColumbusPHPTest extends PHPUnit_Framework_TestCase {
     ]);
     $handler = HandlerStack::create($mock);
     $client = new Client(['handler' => $handler]);
-    $feed = new PokerHandFeedColumbusPHP($client);
+    $feed = new PokerHandFeedRemote($client, 'http://poker.columbusphp.org/hand');
 
     // Get the raw data and try to parse it.
     $data = $feed->getData($feed->getUrl());
@@ -88,7 +88,7 @@ class PokerHandFeedColumbusPHPTest extends PHPUnit_Framework_TestCase {
     ]);
     $handler = HandlerStack::create($mock);
     $client = new Client(['handler' => $handler]);
-    $feed = new PokerHandFeedColumbusPHP($client);
+    $feed = new PokerHandFeedRemote($client, 'http://poker.columbusphp.org/hand');
 
     // Try to get data.
     $data = $feed->getData($feed->getUrl());


### PR DESCRIPTION
I replaced the ColumbusPHP feed with a neutral one that accepts any endpoint. I adjusted run.php to accept `$argv[1]` and pass it into the remote feed as long as it validates as a URL. 