### PR TITLE
Enlarge PHP version testing set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,18 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4snapshot
+  - nightly
   - hhvm
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 7.4snapshot
+    - php: nightly
 
 sudo: false
 


### PR DESCRIPTION
This PR is relative to issue #5

Nightly version and 7.4 must be authorized to failed because there is no stable version